### PR TITLE
fix: floating point bug with delay

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { renderer } from './renderer/renderer.js';
-import { batchAnimate } from './utils.js';
+import { batchAnimate, fixFloat } from './utils.js';
 
 export function clear(store) {
   const { box } = store;
@@ -13,7 +13,7 @@ export function clear(store) {
 
 function framing(store, mediaTime) {
   const { dialogues, actives } = store;
-  const vct = mediaTime - store.delay;
+  const vct = fixFloat(mediaTime - store.delay);
   for (let i = actives.length - 1; i >= 0; i -= 1) {
     const dia = actives[i];
     const { end } = dia;
@@ -44,7 +44,7 @@ export function createSeek(store) {
   return function seek() {
     clear(store);
     const { video, dialogues } = store;
-    const vct = video.currentTime - store.delay;
+    const vct = fixFloat(video.currentTime - store.delay);
     store.index = (() => {
       for (let i = 0; i < dialogues.length; i += 1) {
         if (vct < dialogues[i].end) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,10 @@ export function initAnimation($el, keyframes, options) {
   return animation;
 }
 
+export function fixFloat(n) {
+  return Math.round(n * 1e10) / 1e10;
+}
+
 export function batchAnimate(dia, action) {
   (dia.animations || []).forEach((animation) => {
     animation[action]();


### PR DESCRIPTION
Hello again, 

I have an issue where sometimes when i seek in a video to the start time of a subtitle it doesn't show, or the previous one shows. 

Assuming the .ass file

```
Dialogue: 0,0:00:00.00,0:00:00.28,Default,,0,0,0,,Line one
Dialogue: 0,0:00:00.28,0:00:00.46,Default,,0,0,0,,Line two
```

If the video time is `0.711`, and the delay is `0.431`, thanks to javascript floating point `0.711 - 0.431 = 0.27999999999999997`.

When framing in ass.js runs `0.27999999999999997 < 0.28` so Line one would show.

With the fix in place `0.711 - 0.431 = 0.28`, as `0.28 >= 0.28` Line two would show.