### PR TITLE
fix: use delay in allocate step

### DIFF
--- a/src/renderer/position.js
+++ b/src/renderer/position.js
@@ -1,10 +1,10 @@
 function allocate(dialogue, store) {
-  const { video, space, scale } = store;
+  const { video, space, scale, delay } = store;
   const { layer, margin, width, height, alignment, end } = dialogue;
   const stageWidth = store.width - Math.trunc(scale * (margin.left + margin.right));
   const stageHeight = store.height;
   const vertical = Math.trunc(scale * margin.vertical);
-  const vct = video.currentTime * 100;
+  const vct = (video.currentTime - delay) * 100;
   space[layer] = space[layer] || {
     left: { width: new Uint16Array(stageHeight + 1), end: new Uint32Array(stageHeight + 1) },
     center: { width: new Uint16Array(stageHeight + 1), end: new Uint32Array(stageHeight + 1) },


### PR DESCRIPTION
Hello again!

Just came across a small bug. I was having a problem where dialogues with the same time were overlapping instead of stacking on top of each other.  

I think it's just because we need to take into account any delay.

Thank you!